### PR TITLE
Add bicep to deply appservices

### DIFF
--- a/.github/bicep/deploy-app-service-and-storage.bicep
+++ b/.github/bicep/deploy-app-service-and-storage.bicep
@@ -1,0 +1,68 @@
+param location string = resourceGroup().location
+
+@allowed([ 'nonprod', 'prod' ])
+param environmentType string
+
+
+/**
+ * @param isDeployStorageAccount ストレージアカウントをデプロイするかどうか
+ */
+param isDeployStorageAccount bool
+
+param resourceNameSuffix string = uniqueString(resourceGroup().id)
+
+var appServiceAppName = '$testapp-{resourceNameSuffix}'
+var appServicePlanName = 'testapp-plan-${environmentType}'
+var manualsStorageAccountName = 'test-app-${resourceNameSuffix}'
+
+// 環境ごとの設定
+var environmentConfigurationMap = {
+  nonprod: {
+	appServicePlan: {
+	  sku: {
+		name: 'F1'
+		capacity: 1
+	  }
+	}
+	storageAccount: {
+	  sku: {
+		name: 'Standard_LRS'
+	  }
+	}
+  }
+  prod: {
+	appServicePlan: {
+	  sku: {
+		name: 'S1'
+		capacity: 2
+	  }
+	}
+	storageAccount: {
+	  sku: {
+		name: 'Standard_ZRS'
+	  }
+	}
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
+  name: appServicePlanName
+  location: location
+  sku: environmentConfigurationMap[environmentType].appServicePlan.sku
+}
+
+resource appServiceApp 'Microsoft.Web/sites@2022-03-01' = {
+  name: appServiceAppName
+  location: location
+  properties: {
+	serverFarmId: appServicePlan.id
+	httpsOnly: true
+  }
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = if (isDeployStorageAccount) {
+  name: manualsStorageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: environmentConfigurationMap[environmentType].storageAccount.sku
+}

--- a/.github/workflows/deploy-bicep/deploy-appservice-and-strorage.yaml
+++ b/.github/workflows/deploy-bicep/deploy-appservice-and-strorage.yaml
@@ -1,0 +1,35 @@
+on: [push]
+name: Deploy app service and storage
+jobs:
+    build-and-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            # Checkout code
+            - uses: actions/checkout@v2
+
+            # Log into Azure
+            - uses: azure/login@v1
+              with:
+                  creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+            # Deploy Bicep file
+            - name: deploy
+              id: deploy
+              uses: azure/arm-deploy@v1
+              with:
+                  subscriptionId: ${{ secrets.AZURE_SUBSCRIPTION }}
+                  resourceGroupName: ${{ secrets.AZURE_RG }}
+                  template: .github/bicep/deploy-app-service-and-storage.bicep
+                  parameters: > 
+                    # prodかnonprodかを指定                   
+                    environmentType=${{ secrets.ENVIRONMENT_TYPE }}
+                    # ストレージアカウントをデプロイするかどうか。true/false
+                    isDeployStorageAccount=${{ secrets.IS_DEPLOY_STORAGE_ACCOUNT }}                    
+                  failOnStdErr: true
+
+            # Capture and log standard error output
+            - name: Output deployment logs
+              if: failure()
+              run: |
+                echo "Deployment failed. Here are the logs:"
+                cat $GITHUB_WORKSPACE/deploy.log

--- a/.github/workflows/deploy-bicep/deploy-appservice-and-strorage.yaml
+++ b/.github/workflows/deploy-bicep/deploy-appservice-and-strorage.yaml
@@ -1,4 +1,11 @@
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'bicep/**'
+      
 name: Deploy app service and storage
 jobs:
     build-and-deploy:


### PR DESCRIPTION
This pull request introduces a new Bicep template for deploying an Azure App Service and Storage Account, along with a GitHub Actions workflow to automate the deployment process. The most important changes include the addition of parameters for environment type and storage account deployment, as well as the creation of resources based on these parameters.

### Bicep Template Changes:
* Added parameters for `location`, `environmentType`, `isDeployStorageAccount`, and `resourceNameSuffix` to configure the deployment.
* Defined variables for resource names and environment-specific configurations for App Service and Storage Account.
* Created resources for `appServicePlan`, `appServiceApp`, and optionally `storageAccount` based on the provided parameters.

### GitHub Actions Workflow Changes:
* Added a workflow to trigger on pushes to the `main` branch and paths under `bicep/**`.
* Configured steps to check out the code, log into Azure, and deploy the Bicep template with parameters from GitHub secrets.
* Included a step to capture and log deployment errors if the deployment fails.